### PR TITLE
Minimize installer sizes

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -315,56 +315,24 @@ jobs:
         mkdir -p AppDir/usr/bin
         [ -f AppDir/bin/filmulator ] && mv AppDir/bin/filmulator AppDir/usr/bin/filmulator || true
 
-        # Copy desktop file and icon into the AppDir
-        mkdir -p AppDir/usr/share/applications AppDir/usr/share/icons/hicolor/256x256/apps
-        cp filmulator-gui/resources/linux/filmulator.desktop \
-           AppDir/usr/share/applications/
-        cp filmulator-gui/resources/linux/filmulator.png \
-           AppDir/usr/share/icons/hicolor/256x256/apps/filmulator.png
-        cp filmulator-gui/resources/linux/filmulator.png \
-           AppDir/filmulator.png
-        # appimagetool requires the .desktop file in the AppDir root
-        cp filmulator-gui/resources/linux/filmulator.desktop \
-           AppDir/filmulator.desktop
+        # Use linuxdeploy to handle AppRun, icons, and automated dependency inspection natively
+        wget -q "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage"
+        wget -q "https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-x86_64.AppImage"
+        chmod +x linuxdeploy-x86_64.AppImage linuxdeploy-plugin-qt-x86_64.AppImage
 
-        # Qt is statically linked, but it dynamically links to some system/vcpkg shared
-        # libs (like libdbus-1.so.3, libxcb-icccm.so.4). We dynamically copy all 
-        # shared libraries resolving to our vcpkg installation prefix.
-        mkdir -p AppDir/usr/lib
-        echo "Bundling vcpkg shared libraries..."
+        # Use appimage tool via extraction because runner prevents FUSE
+        # We supply QMAKE path so the qt plugin finds our vcpkg installation
+        APPIMAGE_EXTRACT_AND_RUN=1 QMAKE="${VCPKG_PREFIX}/tools/qt5/bin/qmake" \
+        ./linuxdeploy-x86_64.AppImage \
+            --appdir AppDir \
+            --executable AppDir/usr/bin/filmulator \
+            --desktop-file filmulator-gui/resources/linux/filmulator.desktop \
+            --icon-file filmulator-gui/resources/linux/filmulator.png \
+            --plugin qt \
+            --output appimage
         
-        # 1. First, recursively find dependencies linked natively:
-        ldd AppDir/usr/bin/filmulator | awk '{print $3}' | grep "${VCPKG_PREFIX}" | while read -r lib; do
-          cp -P "$lib"* AppDir/usr/lib/ 2>/dev/null || cp "$lib" AppDir/usr/lib/
-        done
-        
-        # 2. Xcb plugins (icccm, image, keysyms, etc.) are dlopen'd at runtime by Qt and 
-        # won't appear in ldd. Since qtbase5-dev installed them via apt-get build-dep,
-        # explicitly bundle them from the system root into the AppImage.
-        for plugin in icccm image keysyms randr render-util shape sync xfixes xinerama xkb xinput shm util composite damage; do
-          cp -P /usr/lib/x86_64-linux-gnu/libxcb-${plugin}.so* AppDir/usr/lib/ 2>/dev/null || true
-        done
-        # libxkbcommon is also dlopen'd and required by Qt's xcb platform plugin
-        cp -P /usr/lib/x86_64-linux-gnu/libxkbcommon*.so* AppDir/usr/lib/ 2>/dev/null || true
-        cp -P "${VCPKG_PREFIX}"/lib/libxkbcommon*.so* AppDir/usr/lib/ 2>/dev/null || true
-
-        # Write AppRun — sets LD_LIBRARY_PATH so bundled libs are found,
-        # then exec the binary in-place (no rpath rewrite needed).
-        cat > AppDir/AppRun << 'APPRUN'
-        #!/bin/sh
-        HERE="$(dirname "$(readlink -f "$0")")"
-        export LD_LIBRARY_PATH="$HERE/usr/lib:${LD_LIBRARY_PATH:-}"
-        exec "$HERE/usr/bin/filmulator" "$@"
-        APPRUN
-        chmod +x AppDir/AppRun
-
-        # Download appimagetool — packages an AppDir as-is, no library analysis
-        wget -q "https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage"
-        chmod +x appimagetool-x86_64.AppImage
-
-        # Package the AppDir into a final AppImage
-        ARCH=x86_64 APPIMAGE_EXTRACT_AND_RUN=1 \
-        ./appimagetool-x86_64.AppImage AppDir Filmulator-x86_64.AppImage
+        # Rename standard output to exact expected static name
+        mv Filmulator*.AppImage Filmulator-x86_64.AppImage
 
     - name: Upload Linux Artifact
       if: runner.os == 'Linux'

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -170,17 +170,17 @@ jobs:
         $env:PATH = "$vcpkgBinDir;$mingwBin;$env:PATH"
 
         Write-Host "Using ldd to find DLLs actually linked by the binary..."
-        # ldd returns lines like: "  Qt5Core.dll => D:\...\bin\Qt5Core.dll (0x...)"
-        # We want only DLLs that resolve from our vcpkg bin dir (case-insensitive path match)
+        # MinGW ldd outputs unix-style paths: "  Qt5Core.dll => /d/a/.../bin/Qt5Core.dll (0x...)"
+        # We extract just the DLL filename, then check if it exists in our vcpkg bin dir.
+        # This is path-format-agnostic (avoids /d/a/ vs D:\a\ mismatch).
         $lddOutput = & ldd $exePath 2>$null
-        $vcpkgBinDirLower = $vcpkgBinDir.ToLower().Replace('\', '/')
         $vcpkgDlls = $lddOutput | Where-Object { $_ -match "=>" } | ForEach-Object {
             if ($_ -match "=>\s+(\S+)\s+\(") {
-                $matches[1]
+                $filename = Split-Path $matches[1] -Leaf
+                $candidate = "$vcpkgBinDir\$filename"
+                if (Test-Path $candidate) { $candidate }
             }
-        } | Where-Object {
-            $_ -and (Test-Path $_) -and $_.ToLower().Replace('\', '/').StartsWith($vcpkgBinDirLower)
-        }
+        } | Where-Object { $_ }
 
         Write-Host "Copying $($vcpkgDlls.Count) vcpkg DLLs resolved by ldd..."
         foreach ($dllPath in $vcpkgDlls) {
@@ -342,6 +342,17 @@ jobs:
         # linuxdeployqt requires 'qmake' on PATH to detect the Qt installation;
         # without it, it exits with code 1 immediately after parsing the desktop file
         export PATH="${VCPKG_PREFIX}/tools/qt5:${PATH}"
+
+        # --- DIAGNOSTICS: show env before calling linuxdeployqt ---
+        echo "=== which qmake ==="
+        which qmake || echo "qmake NOT found on PATH"
+        echo "=== qmake -v ==="
+        qmake -v 2>&1 || echo "qmake -v failed"
+        echo "=== ls tools/qt5 ==="
+        ls -la "${VCPKG_PREFIX}/tools/qt5/" 2>&1 | head -20 || echo "tools/qt5 not found"
+        echo "=== ldd on filmulator binary ==="
+        LD_LIBRARY_PATH="${VCPKG_PREFIX}/lib" ldd AppDir/usr/bin/filmulator 2>&1 | head -30
+        echo "=== end diagnostics ==="
 
         # linuxdeployqt is an AppImage itself; APPIMAGE_EXTRACT_AND_RUN lets it
         # run without FUSE (which GitHub Actions doesn't have as a kernel module)

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -226,14 +226,19 @@ jobs:
         }
 
         Write-Host "Copying required QML modules..."
-        # Only the QML modules actually imported by the app's QML files
+        # Only the QML modules actually imported by the app's QML files.
+        # NOTE: Do NOT include QtQml here. Connections/Component/QtObject are C++
+        # built-in types registered by Qt5Qml.dll itself. Copying qml/QtQml/ adds a
+        # qmldir that tries to load a plugin overlay (qtqmlplugin.dll); if that plugin
+        # has missing deps it breaks the entire QtQml module registration, making
+        # Connections unavailable. The app uses import QtQuick 2.12 (not QtQml 2.x)
+        # so the built-in registration is all that's needed.
         $qmlMods = @(
             "QtQuick",
             "QtQuick\Controls.2",
             "QtQuick\Layouts",
             "QtQuick\Templates.2",
             "QtQuick\Window.2",
-            "QtQml",
             "Qt\labs\platform",
             "Qt\labs\settings"
         )

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -10,6 +10,9 @@ permissions:
   packages: write
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build:
     name: ${{ matrix.os }}-build
@@ -34,7 +37,7 @@ jobs:
 
     env:
       BUILD_TYPE: Release
-      VCPKG_BINARY_SOURCES: "clear;nuget,https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json,${{ github.event_name == 'pull_request' && 'read' || 'readwrite' }}"
+      VCPKG_BINARY_SOURCES: "clear;nuget,https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json,readwrite"
       VCPKG_DEFAULT_TRIPLET: ${{ matrix.triplet }}
       VCPKG_NUGET_TIMEOUT: 1200
       VCPKG_TARGET_TRIPLET: ${{ matrix.triplet }}

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -401,9 +401,30 @@ jobs:
         ls -la "${VCPKG_PREFIX}/tools/qt5/bin/" 2>&1 | head -20 || echo "tools/qt5/bin not found"
         echo "=== end diagnostics ==="
 
+        # --- PRE-FLIGHT: verify binary, rpath, and Qt presence before linuxdeployqt ---
+        echo "=== Binary location in AppDir ==="
+        find AppDir -name filmulator -type f 2>/dev/null || echo "Binary NOT found in AppDir"
+
+        echo "=== patchelf rpath ==="
+        patchelf --print-rpath AppDir/usr/bin/filmulator 2>&1 || echo "patchelf failed"
+
+        echo "=== ldd on binary ==="
+        ldd AppDir/usr/bin/filmulator 2>&1 || echo "ldd failed"
+
+        echo "=== Qt core libs ==="
+        ls "${VCPKG_PREFIX}/lib/"libQt5Core.so* 2>&1 || echo "Qt libs NOT found"
+
+        echo "=== Qt plugins ==="
+        ls "${VCPKG_PREFIX}/plugins/" 2>&1 | head -20 || echo "plugins dir not found"
+
+        echo "=== QML modules ==="
+        ls "${VCPKG_PREFIX}/qml/" 2>&1 | head -20 || echo "qml dir not found"
+        echo "=== end pre-flight ==="
+
         # linuxdeployqt is an AppImage itself; APPIMAGE_EXTRACT_AND_RUN lets it
         # run without FUSE (which GitHub Actions doesn't have as a kernel module)
         # -unsupported-allow-new-glibc bypasses the Ubuntu 16.04 era glibc check
+        # Use || true so the step continues and prints all output even on failure
         APPIMAGE_EXTRACT_AND_RUN=1 \
         ./linuxdeployqt-continuous-x86_64.AppImage \
           AppDir/usr/share/applications/filmulator.desktop \
@@ -411,7 +432,8 @@ jobs:
           -qmldir=filmulator-gui/qml \
           -extra-plugins=sqldrivers/libqsqlite.so \
           -unsupported-allow-new-glibc \
-          -verbose=2
+          -verbose=3 \
+          || { echo "linuxdeployqt FAILED (see above)"; exit 1; }
 
         # Find the generated AppImage and rename if needed
         APPIMAGE=$(ls *.AppImage 2>/dev/null | grep -v linuxdeployqt | head -1)

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -344,6 +344,9 @@ jobs:
         for plugin in icccm image keysyms randr render-util shape sync xfixes xinerama xkb xinput shm util composite damage; do
           cp -P /usr/lib/x86_64-linux-gnu/libxcb-${plugin}.so* AppDir/usr/lib/ 2>/dev/null || true
         done
+        # libxkbcommon is also dlopen'd and required by Qt's xcb platform plugin
+        cp -P /usr/lib/x86_64-linux-gnu/libxkbcommon*.so* AppDir/usr/lib/ 2>/dev/null || true
+        cp -P "${VCPKG_PREFIX}"/lib/libxkbcommon*.so* AppDir/usr/lib/ 2>/dev/null || true
 
         # Write AppRun — sets LD_LIBRARY_PATH so bundled libs are found,
         # then exec the binary in-place (no rpath rewrite needed).

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -339,8 +339,11 @@ jobs:
         done
         
         # 2. Xcb plugins (icccm, image, keysyms, etc.) are dlopen'd at runtime by Qt and 
-        # won't appear in ldd. Explicitly bundle them from vcpkg.
-        cp -P "${VCPKG_PREFIX}"/lib/libxcb-*.so* AppDir/usr/lib/ 2>/dev/null || true
+        # won't appear in ldd. Since qtbase5-dev installed them via apt-get build-dep,
+        # explicitly bundle them from the system root into the AppImage.
+        for plugin in icccm image keysyms randr render-util shape sync xfixes xinerama xkb; do
+          cp -P /usr/lib/x86_64-linux-gnu/libxcb-${plugin}.so* AppDir/usr/lib/ 2>/dev/null || true
+        done
 
         # Write AppRun — sets LD_LIBRARY_PATH so bundled libs are found,
         # then exec the binary in-place (no rpath rewrite needed).

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -159,146 +159,77 @@ jobs:
       if: runner.os == 'Windows'
       shell: pwsh
       env:
-        VCPKG_PREFIX: ${{ github.workspace }}\build\${{ matrix.preset }}\vcpkg_installed\${{ matrix.triplet }}
+        # vcpkg manifest mode puts dependencies and tools inside the build directory
+        WINDEPLOY_PREFIX: ${{ github.workspace }}\build\${{ matrix.preset }}\vcpkg_installed\${{ matrix.triplet }}
       run: |
         $binDir = "$env:GITHUB_WORKSPACE\build\installed\bin"
-        $exePath = "$binDir\filmulator.exe"
-        $vcpkgBinDir = "$env:VCPKG_PREFIX\bin"
-        $mingwBin = Split-Path (Get-Command g++).Source
-
-        # Add vcpkg bin + MinGW bin to PATH so ldd can resolve all DLLs
-        $env:PATH = "$vcpkgBinDir;$mingwBin;$env:PATH"
-
-        Write-Host "Using ldd to find DLLs actually linked by the binary..."
-        # MinGW ldd outputs unix-style paths: "  Qt5Core.dll => /d/a/.../bin/Qt5Core.dll (0x...)"
-        # We extract just the DLL filename, then check if it exists in our vcpkg bin dir.
-        # This is path-format-agnostic (avoids /d/a/ vs D:\a\ mismatch).
-        $lddOutput = & ldd $exePath 2>$null
-        $vcpkgDlls = $lddOutput | Where-Object { $_ -match "=>" } | ForEach-Object {
-            if ($_ -match "=>\s+(\S+)\s+\(") {
-                $filename = Split-Path $matches[1] -Leaf
-                $candidate = "$vcpkgBinDir\$filename"
-                if (Test-Path $candidate) { $candidate }
-            }
-        } | Where-Object { $_ }
-
-        Write-Host "Copying $($vcpkgDlls.Count) vcpkg DLLs resolved by ldd..."
-        foreach ($dllPath in $vcpkgDlls) {
-            $dllName = Split-Path -Leaf $dllPath
-            Write-Host "  $dllName"
-            Copy-Item $dllPath $binDir -Force
+        $vcpkgBinDir = "$env:WINDEPLOY_PREFIX\bin"
+        
+        Write-Host "Bundling DLLs from $vcpkgBinDir to $binDir"
+        if (Test-Path $vcpkgBinDir) {
+            Copy-Item "$vcpkgBinDir\*.dll" $binDir -Force
+        } else {
+            Write-Error "Could not find vcpkg bin directory at $vcpkgBinDir"
+            exit 1
         }
-
-        # Runtime DLLs that ldd won't show (already on system PATH during ldd)
+        
         Write-Host "Bundling compiler runtime DLLs..."
+        $mingwBin = Split-Path (Get-Command g++).Source
+        Write-Host "MinGW bin directory: $mingwBin"
         $runtimeDlls = @("libstdc++-6.dll", "libgcc_s_seh-1.dll", "libwinpthread-1.dll", "libgomp-1.dll")
         foreach ($dll in $runtimeDlls) {
             $src = "$mingwBin\$dll"
             if (Test-Path $src) {
-                Write-Host "  $dll"
+                Write-Host "Copying $dll from $mingwBin"
                 Copy-Item $src $binDir -Force
             } else {
                 Write-Warning "Could not find $dll in $mingwBin"
             }
         }
 
-        Write-Host "Copying required Qt plugins..."
-        # Only copy the plugin categories the app actually uses
-        $pluginDirs = @{
-            "platforms"    = @("qwindows.dll", "qoffscreen.dll") # required: windowing + headless CI
-            "sqldrivers"   = @("qsqlite.dll")                   # required: SQLite database
-            "imageformats" = @("qjpeg.dll", "qtiff.dll")        # optional: file I/O
-            "iconengines"  = @("qsvgicon.dll")                  # optional: icons
-            "styles"       = @("qwindowsvistastyle.dll")        # optional: native style
-        }
-        foreach ($pluginDir in $pluginDirs.Keys) {
+        Write-Host "Copying Qt plugins..."
+        # Copy essential Qt plugins
+        $pluginDirs = @("platforms", "imageformats", "iconengines", "styles", "sqldrivers")
+        foreach ($pluginDir in $pluginDirs) {
+            $srcPath = "$env:WINDEPLOY_PREFIX\plugins\$pluginDir"
             $dstPath = "$binDir\$pluginDir"
-            New-Item -ItemType Directory -Force -Path $dstPath | Out-Null
-            foreach ($dll in $pluginDirs[$pluginDir]) {
-                $src = "$env:VCPKG_PREFIX\plugins\$pluginDir\$dll"
-                if (Test-Path $src) {
-                    Write-Host "  $pluginDir\$dll"
-                    Copy-Item $src $dstPath -Force
-                } else {
-                    Write-Warning "Plugin not found: $pluginDir\$dll"
-                }
-            }
-        }
-
-        Write-Host "Copying required QML modules..."
-        # Only the QML modules actually imported by the app's QML files.
-        # NOTE: Do NOT include QtQml here. Connections/Component/QtObject are C++
-        # built-in types registered by Qt5Qml.dll itself. Copying qml/QtQml/ adds a
-        # qmldir that tries to load a plugin overlay (qtqmlplugin.dll); if that plugin
-        # has missing deps it breaks the entire QtQml module registration, making
-        # Connections unavailable. The app uses import QtQuick 2.12 (not QtQml 2.x)
-        # so the built-in registration is all that's needed.
-        $qmlMods = @(
-            "QtQuick",
-            "QtQuick\Controls.2",
-            "QtQuick\Layouts",
-            "QtQuick\Templates.2",
-            "QtQuick\Window.2",
-            "QtQml\Models.2",
-            "Qt\labs\platform",
-            "Qt\labs\settings"
-        )
-        $qmlSrc = "$env:VCPKG_PREFIX\qml"
-        foreach ($mod in $qmlMods) {
-            $src = "$qmlSrc\$mod"
-            $dst = "$binDir\qml\$mod"
-            if (Test-Path $src) {
-                Write-Host "  qml\$mod"
-                New-Item -ItemType Directory -Force -Path (Split-Path $dst) | Out-Null
-                Copy-Item $src $dst -Recurse -Force
+            if (Test-Path $srcPath) {
+                Write-Host "Copying $pluginDir plugins..."
+                Copy-Item $srcPath $dstPath -Recurse -Force
             } else {
-                Write-Warning "QML module not found: $mod"
+                Write-Warning "Plugin directory not found: $srcPath"
             }
         }
-
-        # Second pass: QML plugins and platform plugins have their own Qt module
-        # dependencies (e.g. qtquickcontrols2plugin.dll needs Qt5QuickControls2.dll
-        # and Qt5QuickTemplates2.dll). These are loaded at runtime by the QML engine
-        # and are invisible to ldd on the main EXE. Scan all DLLs we just copied
-        # (plugins + QML dirs) and pick up any additional vcpkg deps.
-        Write-Host "Second ldd pass: scanning plugin/QML DLLs for additional vcpkg deps..."
-        $allCopiedDlls = @()
-        foreach ($pluginDir in $pluginDirs.Keys) {
-            $allCopiedDlls += Get-ChildItem "$binDir\$pluginDir" -Filter *.dll -ErrorAction SilentlyContinue
-        }
-        $allCopiedDlls += Get-ChildItem "$binDir\qml" -Filter *.dll -Recurse -ErrorAction SilentlyContinue
-
-        $extraDlls = @{}
-        foreach ($dll in $allCopiedDlls) {
-            $lddOut = & ldd $dll.FullName 2>$null
-            $lddOut | Where-Object { $_ -match "=>" } | ForEach-Object {
-                if ($_ -match "=>\s+(\S+)\s+\(") {
-                    $name = Split-Path $matches[1] -Leaf
-                    $candidate = "$vcpkgBinDir\$name"
-                    if ((Test-Path $candidate) -and -not (Test-Path "$binDir\$name")) {
-                        $extraDlls[$name] = $candidate
-                    }
+        
+        Write-Host "Copying QML modules..."
+        # Copy QML modules (Qt Quick related)
+        $qmlSrcDir = "$env:WINDEPLOY_PREFIX\qml"
+        if (Test-Path $qmlSrcDir) {
+            $qmlDirs = @("QtQuick", "QtQuick.2", "QtQml", "QtQuick\Controls.2", "QtQuick\Layouts", "QtQuick\Templates.2", "QtQuick\Window.2", "Qt\labs\platform", "Qt\labs\settings")
+            foreach ($qmlMod in $qmlDirs) {
+                $srcPath = "$qmlSrcDir\$qmlMod"
+                $dstPath = "$binDir\qml\$qmlMod"
+                if (Test-Path $srcPath) {
+                    Write-Host "Copying QML module: $qmlMod..."
+                    New-Item -ItemType Directory -Force -Path (Split-Path $dstPath) | Out-Null
+                    Copy-Item $srcPath $dstPath -Recurse -Force
+                } else {
+                    Write-Warning "QML module not found: $srcPath"
                 }
-            }
-        }
-        if ($extraDlls.Count -gt 0) {
-            Write-Host "  Copying $($extraDlls.Count) additional vcpkg DLLs from plugin deps:"
-            foreach ($entry in $extraDlls.GetEnumerator()) {
-                Write-Host "    $($entry.Key)"
-                Copy-Item $entry.Value $binDir -Force
             }
         } else {
-            Write-Host "  No additional vcpkg DLLs needed."
+            Write-Warning "QML directory not found at $qmlSrcDir"
         }
-
+        
         Write-Host "Stripping all EXEs and DLLs to significantly reduce package size..."
         Get-ChildItem -Path $binDir -Recurse -Include *.exe, *.dll | ForEach-Object {
             & strip $_.FullName
         }
 
+        # Create qt.conf to help Qt find plugins and QML modules
         Write-Host "Creating qt.conf..."
         "[Paths]`nPlugins = .`nQml2Imports = ./qml" | Out-File -FilePath "$binDir\qt.conf" -Encoding ASCII
-
+        
         Copy-Item "$env:GITHUB_WORKSPACE\LICENSE.txt" $binDir -Force
         Copy-Item "$env:GITHUB_WORKSPACE\filmulator-gui\filmulator-gui80.ico" $binDir -Force
         Copy-Item "$env:GITHUB_WORKSPACE\filmulator_build.iss" "$env:GITHUB_WORKSPACE\build\installed" -Force
@@ -628,25 +559,12 @@ jobs:
         }
         $env:PATH = $oldPath
         
-        Write-Host "=== DLLs in install root ==="
-        Get-ChildItem "$installDir" -Filter *.dll | Select-Object -ExpandProperty Name | Sort-Object
-        Write-Host "=== QML dirs in install ==="
-        Get-ChildItem "$installDir\qml" -Recurse -Directory | Select-Object -ExpandProperty FullName
-
         Write-Host "Running smoke test on installed application..."
         $outputLog = "${{ github.workspace }}\smoke_test_output.log"
         $errorLog = "${{ github.workspace }}\smoke_test_error.log"
         $startTime = Get-Date
-
-        # QT_QPA_PLATFORM: use 'windows' — GitHub Actions Windows VMs have a desktop
-        # session (Windows Server 2022 with GPU), so the native windows platform
-        # works fine and avoids any cascading failure from the offscreen plugin chain.
-        # QML_IMPORT_TRACE + QT_DEBUG_PLUGINS: verbose tracing to diagnose why
-        # 'Connections is not a type' keeps appearing.
-        $env:QT_QPA_PLATFORM = "windows"
-        $env:QT_QUICK_BACKEND = "software"
-        $env:QML_IMPORT_TRACE = "1"
-        $env:QT_DEBUG_PLUGINS = "1"
+        
+        # Start the process and capture output
         $process = Start-Process -FilePath $exePath -PassThru -RedirectStandardOutput $outputLog -RedirectStandardError $errorLog
         
         # Give it some time to load DLLs and fail if there's an issue

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -239,6 +239,7 @@ jobs:
             "QtQuick\Layouts",
             "QtQuick\Templates.2",
             "QtQuick\Window.2",
+            "QtQml\Models.2",
             "Qt\labs\platform",
             "Qt\labs\settings"
         )

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -159,20 +159,48 @@ jobs:
       if: runner.os == 'Windows'
       shell: pwsh
       env:
-        # vcpkg manifest mode puts dependencies and tools inside the build directory
-        WINDEPLOY_PREFIX: ${{ github.workspace }}\build\${{ matrix.preset }}\vcpkg_installed\${{ matrix.triplet }}
+        VCPKG_PREFIX: ${{ github.workspace }}\build\${{ matrix.preset }}\vcpkg_installed\${{ matrix.triplet }}
       run: |
         $binDir = "$env:GITHUB_WORKSPACE\build\installed\bin"
-        $vcpkgBinDir = "$env:WINDEPLOY_PREFIX\bin"
-        
-        Write-Host "Bundling DLLs from $vcpkgBinDir to $binDir"
-        if (Test-Path $vcpkgBinDir) {
-            Copy-Item "$vcpkgBinDir\*.dll" $binDir -Force
-        } else {
-            Write-Error "Could not find vcpkg bin directory at $vcpkgBinDir"
+        $exePath = "$binDir\filmulator.exe"
+        $vcpkgBinDir = "$env:VCPKG_PREFIX\bin"
+        $windeployqt = "$env:VCPKG_PREFIX\tools\qt5\windeployqt.exe"
+
+        if (-not (Test-Path $windeployqt)) {
+            # Fallback: search for windeployqt in tools
+            $windeployqt = Get-ChildItem -Path "$env:VCPKG_PREFIX\tools" -Filter "windeployqt.exe" -Recurse | Select-Object -First 1 -ExpandProperty FullName
+        }
+        if (-not $windeployqt) {
+            Write-Error "windeployqt.exe not found under $env:VCPKG_PREFIX\tools"
             exit 1
         }
-        
+        Write-Host "Using windeployqt: $windeployqt"
+
+        # Add vcpkg bin to PATH so windeployqt can find Qt DLLs
+        $env:PATH = "$vcpkgBinDir;$env:PATH"
+
+        Write-Host "Running windeployqt (smart Qt deployment)..."
+        & $windeployqt `
+          --release `
+          --qmldir "$env:GITHUB_WORKSPACE\filmulator-gui\qml" `
+          --no-translations `
+          --no-system-d3d-compiler `
+          --no-opengl-sw `
+          --dir $binDir `
+          $exePath
+
+        if ($LASTEXITCODE -ne 0) {
+            Write-Error "windeployqt failed with exit code $LASTEXITCODE"
+            exit $LASTEXITCODE
+        }
+
+        Write-Host "Bundling non-Qt vcpkg DLLs..."
+        # Copy only non-Qt DLLs from vcpkg (windeployqt already handled Qt ones)
+        Get-ChildItem "$vcpkgBinDir\*.dll" | Where-Object { $_.Name -notmatch '^Qt' } | ForEach-Object {
+            Write-Host "Copying $_"
+            Copy-Item $_.FullName $binDir -Force
+        }
+
         Write-Host "Bundling compiler runtime DLLs..."
         $mingwBin = Split-Path (Get-Command g++).Source
         Write-Host "MinGW bin directory: $mingwBin"
@@ -180,51 +208,17 @@ jobs:
         foreach ($dll in $runtimeDlls) {
             $src = "$mingwBin\$dll"
             if (Test-Path $src) {
-                Write-Host "Copying $dll from $mingwBin"
+                Write-Host "Copying $dll"
                 Copy-Item $src $binDir -Force
             } else {
                 Write-Warning "Could not find $dll in $mingwBin"
             }
         }
 
-        Write-Host "Copying Qt plugins..."
-        # Copy essential Qt plugins
-        $pluginDirs = @("platforms", "imageformats", "iconengines", "styles", "sqldrivers")
-        foreach ($pluginDir in $pluginDirs) {
-            $srcPath = "$env:WINDEPLOY_PREFIX\plugins\$pluginDir"
-            $dstPath = "$binDir\$pluginDir"
-            if (Test-Path $srcPath) {
-                Write-Host "Copying $pluginDir plugins..."
-                Copy-Item $srcPath $dstPath -Recurse -Force
-            } else {
-                Write-Warning "Plugin directory not found: $srcPath"
-            }
-        }
-        
-        Write-Host "Copying QML modules..."
-        # Copy QML modules (Qt Quick related)
-        $qmlSrcDir = "$env:WINDEPLOY_PREFIX\qml"
-        if (Test-Path $qmlSrcDir) {
-            $qmlDirs = @("QtQuick", "QtQuick.2", "QtQml", "QtQuick\Controls.2", "QtQuick\Layouts", "QtQuick\Templates.2", "QtQuick\Window.2", "Qt\labs\platform", "Qt\labs\settings")
-            foreach ($qmlMod in $qmlDirs) {
-                $srcPath = "$qmlSrcDir\$qmlMod"
-                $dstPath = "$binDir\qml\$qmlMod"
-                if (Test-Path $srcPath) {
-                    Write-Host "Copying QML module: $qmlMod..."
-                    New-Item -ItemType Directory -Force -Path (Split-Path $dstPath) | Out-Null
-                    Copy-Item $srcPath $dstPath -Recurse -Force
-                } else {
-                    Write-Warning "QML module not found: $srcPath"
-                }
-            }
-        } else {
-            Write-Warning "QML directory not found at $qmlSrcDir"
-        }
-        
         # Create qt.conf to help Qt find plugins and QML modules
         Write-Host "Creating qt.conf..."
         "[Paths]`nPlugins = .`nQml2Imports = ./qml" | Out-File -FilePath "$binDir\qt.conf" -Encoding ASCII
-        
+
         Copy-Item "$env:GITHUB_WORKSPACE\LICENSE.txt" $binDir -Force
         Copy-Item "$env:GITHUB_WORKSPACE\filmulator-gui\filmulator-gui80.ico" $binDir -Force
         Copy-Item "$env:GITHUB_WORKSPACE\filmulator_build.iss" "$env:GITHUB_WORKSPACE\build\installed" -Force
@@ -269,51 +263,63 @@ jobs:
       run: |
         # Install dependencies for AppImage creation
         sudo apt-get install -y fuse libfuse2 file patchelf
-        
-        # Download linuxdeploy (without Qt plugin - we'll deploy Qt manually)
-        wget -q https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
-        chmod +x linuxdeploy*.AppImage
-        
+
         # Generate 256x256 icon from SVG
         sudo apt-get install -y librsvg2-bin
         rsvg-convert -w 256 -h 256 filmulator-gui/resources/filmulator64icon.svg \
           -o filmulator-gui/resources/linux/filmulator.png
-        
+
         # Install to AppDir
         cmake --install build/${{ matrix.preset }} --prefix AppDir/usr
-        
-        # Manually deploy Qt libraries (linuxdeploy-plugin-qt has issues with vcpkg Qt)
-        echo "Copying Qt libraries..."
-        mkdir -p AppDir/usr/lib
-        cp -av "${VCPKG_PREFIX}/lib/"libQt5*.so* AppDir/usr/lib/ || true
-        
-        echo "Copying Qt plugins..."
-        mkdir -p AppDir/usr/plugins
-        cp -rv "${VCPKG_PREFIX}/plugins/"* AppDir/usr/plugins/
-        
-        echo "Copying QML modules..."
-        mkdir -p AppDir/usr/qml
-        cp -rv "${VCPKG_PREFIX}/qml/"* AppDir/usr/qml/
-        
-        # Create qt.conf for the AppImage
+
+        # Fix install layout: linuxdeployqt expects executable at usr/bin/<name>
+        mkdir -p AppDir/usr/bin
+        [ -f AppDir/bin/filmulator ] && mv AppDir/bin/filmulator AppDir/usr/bin/filmulator || true
+
+        # Copy desktop file and icon into the AppDir
+        mkdir -p AppDir/usr/share/applications AppDir/usr/share/icons/hicolor/256x256/apps
+        cp filmulator-gui/resources/linux/filmulator.desktop \
+           AppDir/usr/share/applications/
+        cp filmulator-gui/resources/linux/filmulator.png \
+           AppDir/usr/share/icons/hicolor/256x256/apps/filmulator.png
+        cp filmulator-gui/resources/linux/filmulator.png \
+           AppDir/filmulator.png
+
+        # Create qt.conf so Qt finds its plugins/qml inside the AppImage
         cat > AppDir/usr/bin/qt.conf << 'EOF'
         [Paths]
         Prefix = ..
         Plugins = plugins
         Qml2Imports = qml
         EOF
-        
-        # Use linuxdeploy to bundle remaining dependencies and create AppImage
-        ./linuxdeploy-x86_64.AppImage \
-          --appdir AppDir \
-          --executable AppDir/usr/bin/filmulator \
-          --desktop-file filmulator-gui/resources/linux/filmulator.desktop \
-          --icon-file filmulator-gui/resources/linux/filmulator.png \
-          --output appimage
-        
+
+        # Download linuxdeployqt — the Qt-aware smart deployment tool
+        # (same tool as the old .travis.yml; analyses ldd output and copies
+        #  only the Qt/non-Qt libs that are actually needed by the binary)
+        wget -q "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage"
+        chmod +x linuxdeployqt-continuous-x86_64.AppImage
+
+        # Point linuxdeployqt at the vcpkg Qt so it finds plugins & QML
+        export LD_LIBRARY_PATH="${VCPKG_PREFIX}/lib:${LD_LIBRARY_PATH:-}"
+        export QML2_IMPORT_PATH="${VCPKG_PREFIX}/qml"
+        export QT_PLUGIN_PATH="${VCPKG_PREFIX}/plugins"
+        export QTDIR="${VCPKG_PREFIX}"
+
+        # linuxdeployqt is an AppImage itself; APPIMAGE_EXTRACT_AND_RUN lets it
+        # run without FUSE (which GitHub Actions doesn't have as a kernel module)
+        # -unsupported-allow-new-glibc bypasses the Ubuntu 16.04 era glibc check
+        APPIMAGE_EXTRACT_AND_RUN=1 \
+        ./linuxdeployqt-continuous-x86_64.AppImage \
+          AppDir/usr/share/applications/filmulator.desktop \
+          -appimage \
+          -qmldir=filmulator-gui/qml \
+          -extra-plugins=sqldrivers/libqsqlite.so \
+          -unsupported-allow-new-glibc \
+          -verbose=2
+
         # Find the generated AppImage and rename if needed
-        APPIMAGE=$(ls *.AppImage 2>/dev/null | grep -v linuxdeploy | head -1)
-        if [ "$APPIMAGE" != "Filmulator-x86_64.AppImage" ]; then
+        APPIMAGE=$(ls *.AppImage 2>/dev/null | grep -v linuxdeployqt | head -1)
+        if [ -n "$APPIMAGE" ] && [ "$APPIMAGE" != "Filmulator-x86_64.AppImage" ]; then
           mv "$APPIMAGE" Filmulator-x86_64.AppImage
         fi
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -508,8 +508,9 @@ jobs:
         echo "Checking AppImage structure..."
         ./"$APPIMAGE" --appimage-help || true
         
-        # Install xvfb for headless X11 testing and libfuse2 for AppImage (missing on ubuntu-24.04 runners)
-        sudo apt-get install -y xvfb libfuse2
+        # Install xvfb for headless X11 testing, libfuse2 for AppImage (missing on ubuntu-24.04 runners)
+        # Also install system-level OpenGL graphics libraries (libgl1, libegl1) since headless runners lack them by default.
+        sudo apt-get update && sudo apt-get install -y xvfb libfuse2 libgl1 libegl1
         
         echo "Running smoke test with xvfb..."
         # Use xvfb-run to provide virtual X11 display for xcb platform

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -313,6 +313,12 @@ jobs:
         mkdir -p AppDir/usr/bin
         [ -f AppDir/bin/filmulator ] && mv AppDir/bin/filmulator AppDir/usr/bin/filmulator || true
 
+        # cmake --install strips the build rpath (see log: 'Set non-toolchain portion
+        # of runtime path to ""'). Without rpath, ldd can't resolve the vcpkg Qt .so
+        # files, so linuxdeployqt sees zero Qt dependencies and exits with code 1.
+        # Restore the rpath so ldd finds Qt, then linuxdeployqt bundles everything.
+        patchelf --set-rpath "${VCPKG_PREFIX}/lib" AppDir/usr/bin/filmulator
+
         # Copy desktop file and icon into the AppDir
         mkdir -p AppDir/usr/share/applications AppDir/usr/share/icons/hicolor/256x256/apps
         cp filmulator-gui/resources/linux/filmulator.desktop \

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -205,11 +205,11 @@ jobs:
         Write-Host "Copying required Qt plugins..."
         # Only copy the plugin categories the app actually uses
         $pluginDirs = @{
-            "platforms"    = @("qwindows.dll")           # required: windowing
-            "sqldrivers"   = @("qsqlite.dll")            # required: SQLite database
-            "imageformats" = @("qjpeg.dll", "qtiff.dll") # optional: file I/O
-            "iconengines"  = @("qsvgicon.dll")            # optional: icons
-            "styles"       = @("qwindowsvistastyle.dll")  # optional: native style
+            "platforms"    = @("qwindows.dll", "qoffscreen.dll") # required: windowing + headless CI
+            "sqldrivers"   = @("qsqlite.dll")                   # required: SQLite database
+            "imageformats" = @("qjpeg.dll", "qtiff.dll")        # optional: file I/O
+            "iconengines"  = @("qsvgicon.dll")                  # optional: icons
+            "styles"       = @("qwindowsvistastyle.dll")        # optional: native style
         }
         foreach ($pluginDir in $pluginDirs.Keys) {
             $dstPath = "$binDir\$pluginDir"
@@ -297,7 +297,9 @@ jobs:
         VCPKG_PREFIX: ${{ github.workspace }}/build/${{ matrix.preset }}/vcpkg_installed/${{ matrix.triplet }}
       run: |
         # Install dependencies for AppImage creation
-        sudo apt-get install -y fuse libfuse2 file patchelf
+        # qt5-qmake: linuxdeployqt requires a working qmake to detect Qt;
+        #   the qtchooser stub installed by build-dep is broken on this runner
+        sudo apt-get install -y fuse libfuse2 file patchelf qt5-qmake
 
         # Generate 256x256 icon from SVG
         sudo apt-get install -y librsvg2-bin
@@ -339,19 +341,18 @@ jobs:
         export QML2_IMPORT_PATH="${VCPKG_PREFIX}/qml"
         export QT_PLUGIN_PATH="${VCPKG_PREFIX}/plugins"
         export QTDIR="${VCPKG_PREFIX}"
-        # linuxdeployqt requires 'qmake' on PATH to detect the Qt installation;
-        # without it, it exits with code 1 immediately after parsing the desktop file
-        export PATH="${VCPKG_PREFIX}/tools/qt5:${PATH}"
+        # linuxdeployqt requires a working 'qmake' on PATH to detect the Qt installation.
+        # vcpkg puts qmake under tools/qt5/bin/ (not tools/qt5/), and we also installed
+        # qt5-qmake via apt above as a reliable fallback.
+        export PATH="${VCPKG_PREFIX}/tools/qt5/bin:${VCPKG_PREFIX}/tools/qt5:${PATH}"
 
-        # --- DIAGNOSTICS: show env before calling linuxdeployqt ---
+        # --- DIAGNOSTICS: confirm qmake is working before linuxdeployqt ---
         echo "=== which qmake ==="
         which qmake || echo "qmake NOT found on PATH"
         echo "=== qmake -v ==="
         qmake -v 2>&1 || echo "qmake -v failed"
-        echo "=== ls tools/qt5 ==="
-        ls -la "${VCPKG_PREFIX}/tools/qt5/" 2>&1 | head -20 || echo "tools/qt5 not found"
-        echo "=== ldd on filmulator binary ==="
-        LD_LIBRARY_PATH="${VCPKG_PREFIX}/lib" ldd AppDir/usr/bin/filmulator 2>&1 | head -30
+        echo "=== ls tools/qt5/bin ==="
+        ls -la "${VCPKG_PREFIX}/tools/qt5/bin/" 2>&1 | head -20 || echo "tools/qt5/bin not found"
         echo "=== end diagnostics ==="
 
         # linuxdeployqt is an AppImage itself; APPIMAGE_EXTRACT_AND_RUN lets it
@@ -605,7 +606,11 @@ jobs:
         $errorLog = "${{ github.workspace }}\smoke_test_error.log"
         $startTime = Get-Date
         
-        # Start the process and capture output
+        # Start the process and capture output.
+        # QT_QPA_PLATFORM must be set explicitly here — Start-Process spawns a new
+        # process tree and doesn't inherit the job-level env: block variables.
+        $env:QT_QPA_PLATFORM = "offscreen"
+        $env:QT_QUICK_BACKEND = "software"
         $process = Start-Process -FilePath $exePath -PassThru -RedirectStandardOutput $outputLog -RedirectStandardError $errorLog
         
         # Give it some time to load DLLs and fail if there's an issue

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -153,7 +153,7 @@ jobs:
 
     - name: Install (Windows)
       if: runner.os == 'Windows'
-      run: cmake --install build/${{ matrix.preset }} --prefix build/installed
+      run: cmake --install build/${{ matrix.preset }} --prefix build/installed --strip
 
     - name: Bundle DLLs + Qt (Windows)
       if: runner.os == 'Windows'
@@ -291,6 +291,10 @@ jobs:
             Write-Host "  No additional vcpkg DLLs needed."
         }
 
+        Write-Host "Stripping all EXEs and DLLs to significantly reduce package size..."
+        Get-ChildItem -Path $binDir -Recurse -Include *.exe, *.dll | ForEach-Object {
+            & strip $_.FullName
+        }
 
         Write-Host "Creating qt.conf..."
         "[Paths]`nPlugins = .`nQml2Imports = ./qml" | Out-File -FilePath "$binDir\qt.conf" -Encoding ASCII

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -312,23 +312,29 @@ jobs:
         cmake --install build/${{ matrix.preset }} --prefix AppDir/usr --strip
 
         # Fix install layout: appimagetool expects executable at usr/bin/<name>
-        mkdir -p AppDir/usr/bin
+        mkdir -p AppDir/usr/bin AppDir/usr/lib
         [ -f AppDir/bin/filmulator ] && mv AppDir/bin/filmulator AppDir/usr/bin/filmulator || true
 
-        # Use linuxdeploy to handle AppRun, icons, and automated dependency inspection natively
+        # 1. Xcb plugins (icccm, image, keysyms, etc.) are dlopen'd at runtime by Qt and 
+        # won't appear in ldd. Explicitly bundle them into the AppImage before running linuxdeploy
+        for plugin in icccm image keysyms randr render-util shape sync xfixes xinerama xkb xinput shm util composite damage; do
+          cp -P /usr/lib/x86_64-linux-gnu/libxcb-${plugin}.so* AppDir/usr/lib/ 2>/dev/null || true
+        done
+        # libxkbcommon is also dlopen'd and required by Qt's xcb platform plugin
+        cp -P /usr/lib/x86_64-linux-gnu/libxkbcommon*.so* AppDir/usr/lib/ 2>/dev/null || true
+        cp -P "${VCPKG_PREFIX}"/lib/libxkbcommon*.so* AppDir/usr/lib/ 2>/dev/null || true
+
+        # Use purely linuxdeploy to handle standard AppRun, icons, desktop file, and dynamic ldd chasing natively
         wget -q "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage"
-        wget -q "https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-x86_64.AppImage"
-        chmod +x linuxdeploy-x86_64.AppImage linuxdeploy-plugin-qt-x86_64.AppImage
+        chmod +x linuxdeploy-x86_64.AppImage
 
         # Use appimage tool via extraction because runner prevents FUSE
-        # We supply QMAKE path so the qt plugin finds our vcpkg installation
-        APPIMAGE_EXTRACT_AND_RUN=1 QMAKE="${VCPKG_PREFIX}/tools/qt5/bin/qmake" \
+        APPIMAGE_EXTRACT_AND_RUN=1 \
         ./linuxdeploy-x86_64.AppImage \
             --appdir AppDir \
             --executable AppDir/usr/bin/filmulator \
             --desktop-file filmulator-gui/resources/linux/filmulator.desktop \
             --icon-file filmulator-gui/resources/linux/filmulator.png \
-            --plugin qt \
             --output appimage
         
         # Rename standard output to exact expected static name

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -484,8 +484,8 @@ jobs:
         echo "Checking AppImage structure..."
         ./"$APPIMAGE" --appimage-help || true
         
-        # Install xvfb for headless X11 testing (AppImage uses xcb platform)
-        sudo apt-get install -y xvfb
+        # Install xvfb for headless X11 testing and libfuse2 for AppImage (missing on ubuntu-24.04 runners)
+        sudo apt-get install -y xvfb libfuse2
         
         echo "Running smoke test with xvfb..."
         # Use xvfb-run to provide virtual X11 display for xcb platform
@@ -509,6 +509,9 @@ jobs:
     - name: Test DMG (macOS)
       if: runner.os == 'macOS'
       run: |
+        # Install libomp because it is dynamically linked but our macOS bundle doesn't pack homebrew dependencies yet
+        brew install libomp
+        
         DMG="Filmulator-macOS-${{ matrix.triplet }}.dmg"
         
         echo "Verifying DMG exists..."
@@ -583,7 +586,8 @@ jobs:
         QT_QUICK_BACKEND: software
         QT_QPA_PLATFORM: offscreen
       run: |
-        $installer = "output\FilmulatorSetup.exe"
+        # Github artifact download implicitly flattens to the workspace root
+        $installer = "FilmulatorSetup.exe"
         $installDir = "${{ github.workspace }}\test_install"
         Write-Host "Installing Filmulator to $installDir..."
         Start-Process -FilePath $installer -ArgumentList "/VERYSILENT", "/SUPPRESSMSGBOXES", "/DIR=""$installDir""" -Wait

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -423,6 +423,7 @@ jobs:
   test-installers:
     name: ${{ matrix.os }}-test
     needs: build
+    if: ${{ !cancelled() }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -391,6 +391,20 @@ jobs:
           -verbose=2 \
           -libpath="${VCPKG_PREFIX}/lib"
         
+        echo "Bundling libomp manually..."
+        LIBOMP_DIR="$(brew --prefix libomp)/lib"
+        # In case Frameworks directory wasn't created by macdeployqt
+        mkdir -p "$APP_BUNDLE/Contents/Frameworks"
+        cp "$LIBOMP_DIR/libomp.dylib" "$APP_BUNDLE/Contents/Frameworks/"
+        install_name_tool -id @executable_path/../Frameworks/libomp.dylib "$APP_BUNDLE/Contents/Frameworks/libomp.dylib"
+        
+        LIBOMP_LINK_PATH=$(otool -L "$APP_BUNDLE/Contents/MacOS/filmulator" | awk '/libomp/{print $1}')
+        if [ -n "$LIBOMP_LINK_PATH" ]; then
+          install_name_tool -change "$LIBOMP_LINK_PATH" @executable_path/../Frameworks/libomp.dylib "$APP_BUNDLE/Contents/MacOS/filmulator"
+        else
+          echo "Warning: libomp not found in otool -L output. Might not be linked."
+        fi
+        
         echo "Bundle contents:"
         ls -la "$APP_BUNDLE/Contents/MacOS/"
         ls -la "$APP_BUNDLE/Contents/Frameworks/" || echo "No Frameworks dir yet"
@@ -509,9 +523,6 @@ jobs:
     - name: Test DMG (macOS)
       if: runner.os == 'macOS'
       run: |
-        # Install libomp because it is dynamically linked but our macOS bundle doesn't pack homebrew dependencies yet
-        brew install libomp
-        
         DMG="Filmulator-macOS-${{ matrix.triplet }}.dmg"
         
         echo "Verifying DMG exists..."

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -647,16 +647,25 @@ jobs:
         }
         $env:PATH = $oldPath
         
+        Write-Host "=== DLLs in install root ==="
+        Get-ChildItem "$installDir" -Filter *.dll | Select-Object -ExpandProperty Name | Sort-Object
+        Write-Host "=== QML dirs in install ==="
+        Get-ChildItem "$installDir\qml" -Recurse -Directory | Select-Object -ExpandProperty FullName
+
         Write-Host "Running smoke test on installed application..."
         $outputLog = "${{ github.workspace }}\smoke_test_output.log"
         $errorLog = "${{ github.workspace }}\smoke_test_error.log"
         $startTime = Get-Date
-        
-        # Start the process and capture output.
-        # QT_QPA_PLATFORM must be set explicitly here — Start-Process spawns a new
-        # process tree and doesn't inherit the job-level env: block variables.
-        $env:QT_QPA_PLATFORM = "offscreen"
+
+        # QT_QPA_PLATFORM: use 'windows' — GitHub Actions Windows VMs have a desktop
+        # session (Windows Server 2022 with GPU), so the native windows platform
+        # works fine and avoids any cascading failure from the offscreen plugin chain.
+        # QML_IMPORT_TRACE + QT_DEBUG_PLUGINS: verbose tracing to diagnose why
+        # 'Connections is not a type' keeps appearing.
+        $env:QT_QPA_PLATFORM = "windows"
         $env:QT_QUICK_BACKEND = "software"
+        $env:QML_IMPORT_TRACE = "1"
+        $env:QT_DEBUG_PLUGINS = "1"
         $process = Start-Process -FilePath $exePath -PassThru -RedirectStandardOutput $outputLog -RedirectStandardError $errorLog
         
         # Give it some time to load DLLs and fail if there's an issue

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -359,6 +359,9 @@ jobs:
            AppDir/usr/share/icons/hicolor/256x256/apps/filmulator.png
         cp filmulator-gui/resources/linux/filmulator.png \
            AppDir/filmulator.png
+        # appimagetool requires the .desktop file in the AppDir root
+        cp filmulator-gui/resources/linux/filmulator.desktop \
+           AppDir/filmulator.desktop
 
         # Qt is statically linked, so we only need to bundle the one vcpkg
         # shared lib that ldd resolves from vcpkg (libdbus-1.so.3).

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -250,7 +250,42 @@ jobs:
             }
         }
 
-        # qt.conf tells Qt where to find plugins and QML relative to the exe
+        # Second pass: QML plugins and platform plugins have their own Qt module
+        # dependencies (e.g. qtquickcontrols2plugin.dll needs Qt5QuickControls2.dll
+        # and Qt5QuickTemplates2.dll). These are loaded at runtime by the QML engine
+        # and are invisible to ldd on the main EXE. Scan all DLLs we just copied
+        # (plugins + QML dirs) and pick up any additional vcpkg deps.
+        Write-Host "Second ldd pass: scanning plugin/QML DLLs for additional vcpkg deps..."
+        $allCopiedDlls = @()
+        foreach ($pluginDir in $pluginDirs.Keys) {
+            $allCopiedDlls += Get-ChildItem "$binDir\$pluginDir" -Filter *.dll -ErrorAction SilentlyContinue
+        }
+        $allCopiedDlls += Get-ChildItem "$binDir\qml" -Filter *.dll -Recurse -ErrorAction SilentlyContinue
+
+        $extraDlls = @{}
+        foreach ($dll in $allCopiedDlls) {
+            $lddOut = & ldd $dll.FullName 2>$null
+            $lddOut | Where-Object { $_ -match "=>" } | ForEach-Object {
+                if ($_ -match "=>\s+(\S+)\s+\(") {
+                    $name = Split-Path $matches[1] -Leaf
+                    $candidate = "$vcpkgBinDir\$name"
+                    if ((Test-Path $candidate) -and -not (Test-Path "$binDir\$name")) {
+                        $extraDlls[$name] = $candidate
+                    }
+                }
+            }
+        }
+        if ($extraDlls.Count -gt 0) {
+            Write-Host "  Copying $($extraDlls.Count) additional vcpkg DLLs from plugin deps:"
+            foreach ($entry in $extraDlls.GetEnumerator()) {
+                Write-Host "    $($entry.Key)"
+                Copy-Item $entry.Value $binDir -Force
+            }
+        } else {
+            Write-Host "  No additional vcpkg DLLs needed."
+        }
+
+
         Write-Host "Creating qt.conf..."
         "[Paths]`nPlugins = .`nQml2Imports = ./qml" | Out-File -FilePath "$binDir\qt.conf" -Encoding ASCII
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -164,58 +164,93 @@ jobs:
         $binDir = "$env:GITHUB_WORKSPACE\build\installed\bin"
         $exePath = "$binDir\filmulator.exe"
         $vcpkgBinDir = "$env:VCPKG_PREFIX\bin"
-        $windeployqt = "$env:VCPKG_PREFIX\tools\qt5\windeployqt.exe"
-
-        if (-not (Test-Path $windeployqt)) {
-            # Fallback: search for windeployqt in tools
-            $windeployqt = Get-ChildItem -Path "$env:VCPKG_PREFIX\tools" -Filter "windeployqt.exe" -Recurse | Select-Object -First 1 -ExpandProperty FullName
-        }
-        if (-not $windeployqt) {
-            Write-Error "windeployqt.exe not found under $env:VCPKG_PREFIX\tools"
-            exit 1
-        }
-        Write-Host "Using windeployqt: $windeployqt"
-
-        # Add vcpkg bin to PATH so windeployqt can find Qt DLLs
-        $env:PATH = "$vcpkgBinDir;$env:PATH"
-
-        Write-Host "Running windeployqt (smart Qt deployment)..."
-        & $windeployqt `
-          --release `
-          --qmldir "$env:GITHUB_WORKSPACE\filmulator-gui\qml" `
-          --no-translations `
-          --no-system-d3d-compiler `
-          --no-opengl-sw `
-          --dir $binDir `
-          $exePath
-
-        if ($LASTEXITCODE -ne 0) {
-            Write-Error "windeployqt failed with exit code $LASTEXITCODE"
-            exit $LASTEXITCODE
-        }
-
-        Write-Host "Bundling non-Qt vcpkg DLLs..."
-        # Copy only non-Qt DLLs from vcpkg (windeployqt already handled Qt ones)
-        Get-ChildItem "$vcpkgBinDir\*.dll" | Where-Object { $_.Name -notmatch '^Qt' } | ForEach-Object {
-            Write-Host "Copying $_"
-            Copy-Item $_.FullName $binDir -Force
-        }
-
-        Write-Host "Bundling compiler runtime DLLs..."
         $mingwBin = Split-Path (Get-Command g++).Source
-        Write-Host "MinGW bin directory: $mingwBin"
+
+        # Add vcpkg bin + MinGW bin to PATH so ldd can resolve all DLLs
+        $env:PATH = "$vcpkgBinDir;$mingwBin;$env:PATH"
+
+        Write-Host "Using ldd to find DLLs actually linked by the binary..."
+        # ldd returns lines like: "  Qt5Core.dll => D:\...\bin\Qt5Core.dll (0x...)"
+        # We want only DLLs that resolve from our vcpkg bin dir (case-insensitive path match)
+        $lddOutput = & ldd $exePath 2>$null
+        $vcpkgBinDirLower = $vcpkgBinDir.ToLower().Replace('\', '/')
+        $vcpkgDlls = $lddOutput | Where-Object { $_ -match "=>" } | ForEach-Object {
+            if ($_ -match "=>\s+(\S+)\s+\(") {
+                $matches[1]
+            }
+        } | Where-Object {
+            $_ -and (Test-Path $_) -and $_.ToLower().Replace('\', '/').StartsWith($vcpkgBinDirLower)
+        }
+
+        Write-Host "Copying $($vcpkgDlls.Count) vcpkg DLLs resolved by ldd..."
+        foreach ($dllPath in $vcpkgDlls) {
+            $dllName = Split-Path -Leaf $dllPath
+            Write-Host "  $dllName"
+            Copy-Item $dllPath $binDir -Force
+        }
+
+        # Runtime DLLs that ldd won't show (already on system PATH during ldd)
+        Write-Host "Bundling compiler runtime DLLs..."
         $runtimeDlls = @("libstdc++-6.dll", "libgcc_s_seh-1.dll", "libwinpthread-1.dll", "libgomp-1.dll")
         foreach ($dll in $runtimeDlls) {
             $src = "$mingwBin\$dll"
             if (Test-Path $src) {
-                Write-Host "Copying $dll"
+                Write-Host "  $dll"
                 Copy-Item $src $binDir -Force
             } else {
                 Write-Warning "Could not find $dll in $mingwBin"
             }
         }
 
-        # Create qt.conf to help Qt find plugins and QML modules
+        Write-Host "Copying required Qt plugins..."
+        # Only copy the plugin categories the app actually uses
+        $pluginDirs = @{
+            "platforms"    = @("qwindows.dll")           # required: windowing
+            "sqldrivers"   = @("qsqlite.dll")            # required: SQLite database
+            "imageformats" = @("qjpeg.dll", "qtiff.dll") # optional: file I/O
+            "iconengines"  = @("qsvgicon.dll")            # optional: icons
+            "styles"       = @("qwindowsvistastyle.dll")  # optional: native style
+        }
+        foreach ($pluginDir in $pluginDirs.Keys) {
+            $dstPath = "$binDir\$pluginDir"
+            New-Item -ItemType Directory -Force -Path $dstPath | Out-Null
+            foreach ($dll in $pluginDirs[$pluginDir]) {
+                $src = "$env:VCPKG_PREFIX\plugins\$pluginDir\$dll"
+                if (Test-Path $src) {
+                    Write-Host "  $pluginDir\$dll"
+                    Copy-Item $src $dstPath -Force
+                } else {
+                    Write-Warning "Plugin not found: $pluginDir\$dll"
+                }
+            }
+        }
+
+        Write-Host "Copying required QML modules..."
+        # Only the QML modules actually imported by the app's QML files
+        $qmlMods = @(
+            "QtQuick",
+            "QtQuick\Controls.2",
+            "QtQuick\Layouts",
+            "QtQuick\Templates.2",
+            "QtQuick\Window.2",
+            "QtQml",
+            "Qt\labs\platform",
+            "Qt\labs\settings"
+        )
+        $qmlSrc = "$env:VCPKG_PREFIX\qml"
+        foreach ($mod in $qmlMods) {
+            $src = "$qmlSrc\$mod"
+            $dst = "$binDir\qml\$mod"
+            if (Test-Path $src) {
+                Write-Host "  qml\$mod"
+                New-Item -ItemType Directory -Force -Path (Split-Path $dst) | Out-Null
+                Copy-Item $src $dst -Recurse -Force
+            } else {
+                Write-Warning "QML module not found: $mod"
+            }
+        }
+
+        # qt.conf tells Qt where to find plugins and QML relative to the exe
         Write-Host "Creating qt.conf..."
         "[Paths]`nPlugins = .`nQml2Imports = ./qml" | Out-File -FilePath "$binDir\qt.conf" -Encoding ASCII
 
@@ -304,6 +339,9 @@ jobs:
         export QML2_IMPORT_PATH="${VCPKG_PREFIX}/qml"
         export QT_PLUGIN_PATH="${VCPKG_PREFIX}/plugins"
         export QTDIR="${VCPKG_PREFIX}"
+        # linuxdeployqt requires 'qmake' on PATH to detect the Qt installation;
+        # without it, it exits with code 1 immediately after parsing the desktop file
+        export PATH="${VCPKG_PREFIX}/tools/qt5:${PATH}"
 
         # linuxdeployqt is an AppImage itself; APPIMAGE_EXTRACT_AND_RUN lets it
         # run without FUSE (which GitHub Actions doesn't have as a kernel module)

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -66,6 +66,8 @@ jobs:
         sudo sed -i 's/^Types: deb$/Types: deb deb-src/' /etc/apt/sources.list.d/ubuntu.sources
         sudo apt-get update
         sudo apt-get build-dep -y qtbase5-dev
+        # Remove unwanted database headers so Qt doesn't compile their sqldrivers and create dependencies
+        sudo apt-get remove -y freetds-dev libsybdb5 unixodbc-dev libpq-dev libmysqlclient-dev || true
         sudo apt-get install -y \
           ninja-build \
           mold \
@@ -147,6 +149,18 @@ jobs:
 
     - name: Configure CMake
       run: cmake --preset ${{ matrix.preset }} -DVCPKG_TARGET_TRIPLET=${{ matrix.triplet }}
+
+    - name: Print vcpkg ABI info
+      if: always()
+      shell: bash
+      run: |
+        echo "=== vcpkg ABI Info ==="
+        find "build/${{ matrix.preset }}/vcpkg_installed" -name "*.vcpkg_abi_info.txt" -type f 2>/dev/null | while read -r f; do
+            echo "--------------------------------------------------------"
+            echo "FILE: $f"
+            echo "--------------------------------------------------------"
+            cat "$f"
+        done || echo "No ABI info files found or directory does not exist."
 
     - name: Build
       run: cmake --build --preset ${{ matrix.preset }}
@@ -406,6 +420,41 @@ jobs:
         name: filmulator-macos-dmg
         path: Filmulator-macOS-*.dmg
 
+  test-installers:
+    name: ${{ matrix.os }}-test
+    needs: build
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        include:
+          - os: ubuntu-latest
+            triplet: x64-linux
+          - os: windows-latest
+            triplet: x64-mingw-dynamic
+          - os: macos-latest
+            triplet: arm64-osx
+
+    steps:
+    - name: Download Linux Artifact
+      if: runner.os == 'Linux'
+      uses: actions/download-artifact@v4
+      with:
+        name: filmulator-linux-appimage
+
+    - name: Download macOS Artifact
+      if: runner.os == 'macOS'
+      uses: actions/download-artifact@v4
+      with:
+        name: filmulator-macos-dmg
+
+    - name: Download Windows Artifact
+      if: runner.os == 'Windows'
+      uses: actions/download-artifact@v4
+      with:
+        name: filmulator-windows-installer
+
     - name: Test AppImage (Linux)
       if: runner.os == 'Linux'
       run: |
@@ -518,7 +567,6 @@ jobs:
     - name: Test Installer (Windows)
       if: runner.os == 'Windows'
       shell: pwsh
-      working-directory: build/installed
       env:
         QT_QUICK_BACKEND: software
         QT_QPA_PLATFORM: offscreen

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -327,19 +327,20 @@ jobs:
         cp filmulator-gui/resources/linux/filmulator.desktop \
            AppDir/filmulator.desktop
 
-        # Qt is statically linked, so we only need to bundle the one vcpkg
-        # shared lib that ldd resolves from vcpkg (libdbus-1.so.3).
-        # All Qt code, plugins, and QML types are compiled into the binary.
+        # Qt is statically linked, but it dynamically links to some system/vcpkg shared
+        # libs (like libdbus-1.so.3, libxcb-icccm.so.4). We dynamically copy all 
+        # shared libraries resolving to our vcpkg installation prefix.
         mkdir -p AppDir/usr/lib
-        DBUS_SO=$(ldd AppDir/usr/bin/filmulator \
-          | awk '/libdbus-1/{print $3}' \
-          | grep "${VCPKG_PREFIX}" || true)
-        if [ -n "$DBUS_SO" ]; then
-          echo "Bundling vcpkg dbus: $DBUS_SO"
-          cp -P "$DBUS_SO"* AppDir/usr/lib/ 2>/dev/null || cp "$DBUS_SO" AppDir/usr/lib/
-        else
-          echo "libdbus-1 not from vcpkg (or not linked) — skipping bundle"
-        fi
+        echo "Bundling vcpkg shared libraries..."
+        
+        # 1. First, recursively find dependencies linked natively:
+        ldd AppDir/usr/bin/filmulator | awk '{print $3}' | grep "${VCPKG_PREFIX}" | while read -r lib; do
+          cp -P "$lib"* AppDir/usr/lib/ 2>/dev/null || cp "$lib" AppDir/usr/lib/
+        done
+        
+        # 2. Xcb plugins (icccm, image, keysyms, etc.) are dlopen'd at runtime by Qt and 
+        # won't appear in ldd. Explicitly bundle them from vcpkg.
+        cp -P "${VCPKG_PREFIX}"/lib/libxcb-*.so* AppDir/usr/lib/ 2>/dev/null || true
 
         # Write AppRun — sets LD_LIBRARY_PATH so bundled libs are found,
         # then exec the binary in-place (no rpath rewrite needed).

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -155,12 +155,23 @@ jobs:
       shell: bash
       run: |
         echo "=== vcpkg ABI Info ==="
-        find "build/${{ matrix.preset }}/vcpkg_installed" -name "*.vcpkg_abi_info.txt" -type f 2>/dev/null | while read -r f; do
+        if [ ! -d "build/${{ matrix.preset }}/vcpkg_installed" ]; then
+            echo "Directory build/${{ matrix.preset }}/vcpkg_installed does not exist."
+            exit 0
+        fi
+        
+        found=0
+        while IFS= read -r f; do
+            found=1
             echo "--------------------------------------------------------"
             echo "FILE: $f"
             echo "--------------------------------------------------------"
             cat "$f"
-        done || echo "No ABI info files found or directory does not exist."
+        done < <(find "build/${{ matrix.preset }}/vcpkg_installed" -name "*vcpkg_abi_info.txt" -type f 2>/dev/null)
+        
+        if [ $found -eq 0 ]; then
+            echo "No ABI info files found."
+        fi
 
     - name: Build
       run: cmake --build --preset ${{ matrix.preset }}

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -341,7 +341,7 @@ jobs:
         # 2. Xcb plugins (icccm, image, keysyms, etc.) are dlopen'd at runtime by Qt and 
         # won't appear in ldd. Since qtbase5-dev installed them via apt-get build-dep,
         # explicitly bundle them from the system root into the AppImage.
-        for plugin in icccm image keysyms randr render-util shape sync xfixes xinerama xkb; do
+        for plugin in icccm image keysyms randr render-util shape sync xfixes xinerama xkb xinput shm util composite damage; do
           cp -P /usr/lib/x86_64-linux-gnu/libxcb-${plugin}.so* AppDir/usr/lib/ 2>/dev/null || true
         done
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -337,8 +337,7 @@ jobs:
             --icon-file filmulator-gui/resources/linux/filmulator.png \
             --output appimage
         
-        # Rename standard output to exact expected static name
-        mv Filmulator*.AppImage Filmulator-x86_64.AppImage
+
 
     - name: Upload Linux Artifact
       if: runner.os == 'Linux'

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -346,7 +346,7 @@ jobs:
           -o filmulator-gui/resources/linux/filmulator.png
 
         # Install to AppDir
-        cmake --install build/${{ matrix.preset }} --prefix AppDir/usr
+        cmake --install build/${{ matrix.preset }} --prefix AppDir/usr --strip
 
         # Fix install layout: appimagetool expects executable at usr/bin/<name>
         mkdir -p AppDir/usr/bin

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -337,9 +337,7 @@ jobs:
         VCPKG_PREFIX: ${{ github.workspace }}/build/${{ matrix.preset }}/vcpkg_installed/${{ matrix.triplet }}
       run: |
         # Install dependencies for AppImage creation
-        # qt5-qmake: linuxdeployqt requires a working qmake to detect Qt;
-        #   the qtchooser stub installed by build-dep is broken on this runner
-        sudo apt-get install -y fuse libfuse2 file patchelf qt5-qmake
+        sudo apt-get install -y fuse libfuse2 file patchelf
 
         # Generate 256x256 icon from SVG
         sudo apt-get install -y librsvg2-bin
@@ -349,15 +347,9 @@ jobs:
         # Install to AppDir
         cmake --install build/${{ matrix.preset }} --prefix AppDir/usr
 
-        # Fix install layout: linuxdeployqt expects executable at usr/bin/<name>
+        # Fix install layout: appimagetool expects executable at usr/bin/<name>
         mkdir -p AppDir/usr/bin
         [ -f AppDir/bin/filmulator ] && mv AppDir/bin/filmulator AppDir/usr/bin/filmulator || true
-
-        # cmake --install strips the build rpath (see log: 'Set non-toolchain portion
-        # of runtime path to ""'). Without rpath, ldd can't resolve the vcpkg Qt .so
-        # files, so linuxdeployqt sees zero Qt dependencies and exits with code 1.
-        # Restore the rpath so ldd finds Qt, then linuxdeployqt bundles everything.
-        patchelf --set-rpath "${VCPKG_PREFIX}/lib" AppDir/usr/bin/filmulator
 
         # Copy desktop file and icon into the AppDir
         mkdir -p AppDir/usr/share/applications AppDir/usr/share/icons/hicolor/256x256/apps
@@ -368,78 +360,37 @@ jobs:
         cp filmulator-gui/resources/linux/filmulator.png \
            AppDir/filmulator.png
 
-        # Create qt.conf so Qt finds its plugins/qml inside the AppImage
-        cat > AppDir/usr/bin/qt.conf << 'EOF'
-        [Paths]
-        Prefix = ..
-        Plugins = plugins
-        Qml2Imports = qml
-        EOF
-
-        # Download linuxdeployqt — the Qt-aware smart deployment tool
-        # (same tool as the old .travis.yml; analyses ldd output and copies
-        #  only the Qt/non-Qt libs that are actually needed by the binary)
-        wget -q "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage"
-        chmod +x linuxdeployqt-continuous-x86_64.AppImage
-
-        # Point linuxdeployqt at the vcpkg Qt so it finds plugins & QML
-        export LD_LIBRARY_PATH="${VCPKG_PREFIX}/lib:${LD_LIBRARY_PATH:-}"
-        export QML2_IMPORT_PATH="${VCPKG_PREFIX}/qml"
-        export QT_PLUGIN_PATH="${VCPKG_PREFIX}/plugins"
-        export QTDIR="${VCPKG_PREFIX}"
-        # linuxdeployqt requires a working 'qmake' on PATH to detect the Qt installation.
-        # vcpkg puts qmake under tools/qt5/bin/ (not tools/qt5/), and we also installed
-        # qt5-qmake via apt above as a reliable fallback.
-        export PATH="${VCPKG_PREFIX}/tools/qt5/bin:${VCPKG_PREFIX}/tools/qt5:${PATH}"
-
-        # --- DIAGNOSTICS: confirm qmake is working before linuxdeployqt ---
-        echo "=== which qmake ==="
-        which qmake || echo "qmake NOT found on PATH"
-        echo "=== qmake -v ==="
-        qmake -v 2>&1 || echo "qmake -v failed"
-        echo "=== ls tools/qt5/bin ==="
-        ls -la "${VCPKG_PREFIX}/tools/qt5/bin/" 2>&1 | head -20 || echo "tools/qt5/bin not found"
-        echo "=== end diagnostics ==="
-
-        # --- PRE-FLIGHT: verify binary, rpath, and Qt presence before linuxdeployqt ---
-        echo "=== Binary location in AppDir ==="
-        find AppDir -name filmulator -type f 2>/dev/null || echo "Binary NOT found in AppDir"
-
-        echo "=== patchelf rpath ==="
-        patchelf --print-rpath AppDir/usr/bin/filmulator 2>&1 || echo "patchelf failed"
-
-        echo "=== ldd on binary ==="
-        ldd AppDir/usr/bin/filmulator 2>&1 || echo "ldd failed"
-
-        echo "=== Qt core libs ==="
-        ls "${VCPKG_PREFIX}/lib/"libQt5Core.so* 2>&1 || echo "Qt libs NOT found"
-
-        echo "=== Qt plugins ==="
-        ls "${VCPKG_PREFIX}/plugins/" 2>&1 | head -20 || echo "plugins dir not found"
-
-        echo "=== QML modules ==="
-        ls "${VCPKG_PREFIX}/qml/" 2>&1 | head -20 || echo "qml dir not found"
-        echo "=== end pre-flight ==="
-
-        # linuxdeployqt is an AppImage itself; APPIMAGE_EXTRACT_AND_RUN lets it
-        # run without FUSE (which GitHub Actions doesn't have as a kernel module)
-        # -unsupported-allow-new-glibc bypasses the Ubuntu 16.04 era glibc check
-        # Use || true so the step continues and prints all output even on failure
-        APPIMAGE_EXTRACT_AND_RUN=1 \
-        ./linuxdeployqt-continuous-x86_64.AppImage \
-          AppDir/usr/share/applications/filmulator.desktop \
-          -appimage \
-          -qmldir=filmulator-gui/qml \
-          -extra-plugins=sqldrivers/libqsqlite.so \
-          -unsupported-allow-new-glibc \
-          -verbose=3 \
-          || { echo "linuxdeployqt FAILED (see above)"; exit 1; }
-
-        # Find the generated AppImage and rename if needed
-        APPIMAGE=$(ls *.AppImage 2>/dev/null | grep -v linuxdeployqt | head -1)
-        if [ -n "$APPIMAGE" ] && [ "$APPIMAGE" != "Filmulator-x86_64.AppImage" ]; then
-          mv "$APPIMAGE" Filmulator-x86_64.AppImage
+        # Qt is statically linked, so we only need to bundle the one vcpkg
+        # shared lib that ldd resolves from vcpkg (libdbus-1.so.3).
+        # All Qt code, plugins, and QML types are compiled into the binary.
+        mkdir -p AppDir/usr/lib
+        DBUS_SO=$(ldd AppDir/usr/bin/filmulator \
+          | awk '/libdbus-1/{print $3}' \
+          | grep "${VCPKG_PREFIX}" || true)
+        if [ -n "$DBUS_SO" ]; then
+          echo "Bundling vcpkg dbus: $DBUS_SO"
+          cp -P "$DBUS_SO"* AppDir/usr/lib/ 2>/dev/null || cp "$DBUS_SO" AppDir/usr/lib/
+        else
+          echo "libdbus-1 not from vcpkg (or not linked) — skipping bundle"
         fi
+
+        # Write AppRun — sets LD_LIBRARY_PATH so bundled libs are found,
+        # then exec the binary in-place (no rpath rewrite needed).
+        cat > AppDir/AppRun << 'APPRUN'
+        #!/bin/sh
+        HERE="$(dirname "$(readlink -f "$0")")"
+        export LD_LIBRARY_PATH="$HERE/usr/lib:${LD_LIBRARY_PATH:-}"
+        exec "$HERE/usr/bin/filmulator" "$@"
+        APPRUN
+        chmod +x AppDir/AppRun
+
+        # Download appimagetool — packages an AppDir as-is, no library analysis
+        wget -q "https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage"
+        chmod +x appimagetool-x86_64.AppImage
+
+        # Package the AppDir into a final AppImage
+        ARCH=x86_64 APPIMAGE_EXTRACT_AND_RUN=1 \
+        ./appimagetool-x86_64.AppImage AppDir Filmulator-x86_64.AppImage
 
     - name: Upload Linux Artifact
       if: runner.os == 'Linux'


### PR DESCRIPTION
Strip out debug symbols to reduce installer sizes.

In the meantime:

* clean up how we do deploy
* fix cmake caching by allowing writes to cache in PRs
* have better smoke tests by testing installers on fresh images